### PR TITLE
Add unit tests for board and search logic

### DIFF
--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,0 +1,37 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from collections import Counter
+
+from board import place_word, compute_board_score, board_valid
+from utils import N
+
+def empty_board():
+    return [["" for _ in range(N)] for _ in range(N)]
+
+
+def empty_bonus():
+    return [["" for _ in range(N)] for _ in range(N)]
+
+
+def test_compute_board_score_basic():
+    board = empty_board()
+    bonus = empty_bonus()
+    place_word(board, "HELLO", 0, 0, 'H')
+    bonus[0][1] = 'DL'
+    bonus[0][4] = 'DW'
+    assert compute_board_score(board, bonus) == 18
+
+
+def test_board_valid_true():
+    board = empty_board()
+    place_word(board, "HELLO", 0, 0, 'H')
+    assert board_valid(board, {"HELLO"})
+
+
+def test_board_valid_false():
+    board = empty_board()
+    place_word(board, "HELXO", 0, 0, 'H')
+    assert not board_valid(board, {"HELLO"})
+

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,41 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from collections import Counter
+
+from search import can_play_word_on_board, is_valid_placement
+from utils import N
+
+def empty_board():
+    return [["" for _ in range(N)] for _ in range(N)]
+
+
+def test_can_play_word_success():
+    board = empty_board()
+    board[0][0] = 'H'
+    can_play, remaining = can_play_word_on_board("HI", 0, 0, 'H', board, Counter({'I':1}))
+    assert can_play
+    assert remaining['I'] == 0
+
+
+def test_can_play_word_fail():
+    board = empty_board()
+    can_play, _ = can_play_word_on_board("HELLO", 0, 0, 'H', board, Counter('HI'))
+    assert not can_play
+
+
+def test_is_valid_placement_cross_invalid():
+    board = empty_board()
+    board[0][1] = 'X'
+    rack = Counter('HI')
+    assert not is_valid_placement('HI', board, rack, {'HI'}, 0, 0, 'V')
+
+
+def test_is_valid_placement_cross_valid():
+    board = empty_board()
+    board[0][1] = 'I'
+    rack = Counter('HI')
+    assert is_valid_placement('HI', board, rack, {'HI'}, 0, 0, 'V')
+
+


### PR DESCRIPTION
## Summary
- add tests for board scoring and validity
- add tests for can_play_word_on_board and is_valid_placement

## Testing
- `pip install -r requires.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862bfffa34c83229beb3aa4413934ed