### PR TITLE
Improve print synchronization

### DIFF
--- a/board.py
+++ b/board.py
@@ -1,10 +1,7 @@
 # --- board.py ---
 
 from colorama import Fore, Style
-from utils import N, LETTER_SCORES, log_with_time, vlog
-import threading
-
-_print_lock = threading.Lock()
+from utils import N, LETTER_SCORES, log_with_time, vlog, PRINT_LOCK
 
 # Helper: precompute a mask of letter positions for a board
 # Returns a 2D list of bools: True if cell is a letter, else False
@@ -12,7 +9,9 @@ def get_letter_mask(board):
     return [[len(cell) == 1 for cell in row] for row in board]
 
 def print_board(board):
-    with _print_lock:
+    """Thread-safe printing of a board."""
+    with PRINT_LOCK:
+        lines = []
         for row in board:
             line = []
             for cell in row:
@@ -28,8 +27,9 @@ def print_board(board):
                     line.append(Fore.GREEN + f' {cell}' + Style.RESET_ALL)
                 else:
                     line.append(Style.DIM + '··' + Style.RESET_ALL)
-            print(' '.join(line))
-        print()
+            lines.append(' '.join(line))
+        print('\n'.join(lines), flush=True)
+        print(flush=True)
 
 def place_word(board, w, r0, c0, d):
     for i, ch in enumerate(w):

--- a/search.py
+++ b/search.py
@@ -3,7 +3,7 @@
 from collections import Counter
 import concurrent.futures
 import time
-from utils import log_with_time, vlog, N
+from utils import log_with_time, vlog, N, PRINT_LOCK
 from board import board_valid, place_word, print_board
 from score_cache import cached_board_score, board_to_tuple
 
@@ -288,11 +288,13 @@ def parallel_first_beam(board, rack, words, wordset, original_bonus, beam_width=
                     seen_boards.add(board_key)
                     if score > best_total:
                         best_total = score
-                        print(f"\nNew best score found: {score}")
+                        with PRINT_LOCK:
+                            print(f"\nNew best score found: {score}", flush=True)
                         print_board(board_result)
                         best_results = [(score, board_result, moves)]
                     elif score == best_total:
-                        print(f"\nEqual best score found: {score}")
+                        with PRINT_LOCK:
+                            print(f"\nEqual best score found: {score}", flush=True)
                         print_board(board_result)
                         best_results.append((score, board_result, moves))
 

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 # --- utils.py ---
 
 import time
+import threading
 
 # Board dimension
 N = 5
@@ -27,12 +28,16 @@ LETTER_SCORES = {
 VERBOSE = False
 start_time = None
 
+# Lock used for synchronized printing across threads
+PRINT_LOCK = threading.Lock()
+
 def log_with_time(msg):
     global start_time
     elapsed = time.time() - start_time
     mins = int(elapsed // 60)
     secs = elapsed % 60
-    print(f"[{mins:02}:{secs:06.3f}] {msg}")
+    with PRINT_LOCK:
+        print(f"[{mins:02}:{secs:06.3f}] {msg}", flush=True)
 
 def vlog(msg, t0=None):
     if VERBOSE:


### PR DESCRIPTION
## Summary
- add a global PRINT_LOCK in utils for synchronized output
- update board printing to use the shared lock
- protect high-score output with PRINT_LOCK

## Testing
- `python main.py --beam-width 5 --depth 5`

------
https://chatgpt.com/codex/tasks/task_e_6866e2f57be4832286af799683f6c630