### PR TITLE
Replace H/V direction with A/D via enum

### DIFF
--- a/board.py
+++ b/board.py
@@ -31,7 +31,7 @@ def leaderboard_gamestate_to_board(game_state):
     return board, bonus_board
 
 from colorama import Fore, Style
-from utils import N, LETTER_SCORES, log_with_time, vlog, PRINT_LOCK
+from utils import N, LETTER_SCORES, log_with_time, vlog, PRINT_LOCK, Direction
 
 # Helper: precompute a mask of letter positions for a board
 # Returns a 2D list of bools: True if cell is a letter, else False
@@ -71,10 +71,11 @@ def print_board(board, bonus=None):
         print(flush=True)
 
 def place_word(board, w, r0, c0, d):
+    """Place ``w`` on ``board`` starting at ``r0,c0`` in direction ``d``."""
     N = len(board)
     for i, ch in enumerate(w):
-        r = r0 + (i if d == 'V' else 0)
-        c = c0 + (i if d == 'H' else 0)
+        r = r0 + (i if d == Direction.DOWN else 0)
+        c = c0 + (i if d == Direction.ACROSS else 0)
         if 0 <= r < N and 0 <= c < N:
             board[r][c] = ch
 

--- a/solver.py
+++ b/solver.py
@@ -25,7 +25,7 @@ import time
 import requests
 from collections import Counter
 import utils
-from utils import N, MAPPING, log_with_time, vlog, LETTER_SCORES
+from utils import N, MAPPING, log_with_time, vlog, LETTER_SCORES, Direction
 import os
 from colorama import Fore
 from board import print_board, compute_board_score
@@ -104,7 +104,7 @@ def run_solver():
                         help='After initial search, explore all subsequent moves for the best starting word. Optionally specify beam width (default: 1000)')
     parser.add_argument('--load-log', type=str, default=None, help='Path to a JSON log file to load the puzzle from instead of calling the API')
     parser.add_argument('--start-word', type=str, default=None, help='Specify a start word to force as the first move')
-    parser.add_argument('--start-pos', type=str, default=None, help='Specify position and direction for start word as "row,col,dir" (e.g. "7,7,H"). Only valid if --start-word is provided.')
+    parser.add_argument('--start-pos', type=str, default=None, help='Specify position and direction for start word as "row,col,dir" (e.g. "7,7,A"). Only valid if --start-word is provided.')
     parser.add_argument('--num-games', type=int, default=50, help='Number of games to play in parallel (default: 50)')
     args = parser.parse_args()
 
@@ -209,6 +209,7 @@ def run_solver():
                 row = int(row)
                 col = int(col)
                 dirn = dirn.upper()
+                dir_enum = Direction.ACROSS if dirn == Direction.ACROSS.value else Direction.DOWN
                 # Find all valid placements for the start word
                 valid_placements = find_best(
                     board,
@@ -222,14 +223,14 @@ def run_solver():
                 # Find placement matching user input
                 for p in valid_placements:
                     # p = (score, word, dir, row, col, ...)
-                    if p[2] == dirn and p[3] == row and p[4] == col:
+                    if p[2] == dir_enum and p[3] == row and p[4] == col:
                         placement = p
                         break
                 if not placement:
-                    log_with_time(f"Cannot place start word '{start_word}' at ({row},{col}) {dirn}.", color=Fore.RED)
+                    log_with_time(f"Cannot place start word '{start_word}' at {row},{col},{dirn}.", color=Fore.RED)
                     return
             except Exception as e:
-                log_with_time(f"Invalid --start-word-pos format. Use row,col,dir (e.g. 7,7,H). Error: {e}", color=Fore.RED)
+                log_with_time(f"Invalid --start-word-pos format. Use row,col,dir (e.g. 7,7,A). Error: {e}", color=Fore.RED)
                 return
         else:
             valid_placements = find_best(
@@ -245,7 +246,7 @@ def run_solver():
                 log_with_time(f"No valid placements for start word '{start_word}' on the board.", color=Fore.RED)
                 return
             placement = max(valid_placements, key=lambda x: x[0])
-        log_with_time(f"Best placement for '{start_word}': score {placement[0]}, position ({placement[3]},{placement[4]}) {placement[2]}", color=Fore.YELLOW)
+        log_with_time(f"Best placement for '{start_word}': score {placement[0]}, position {placement[3]},{placement[4]},{placement[2]}", color=Fore.YELLOW)
         rack_after_first = rack_counter.copy()
         for ch in start_word:
             rack_after_first[ch] -= 1
@@ -265,7 +266,7 @@ def run_solver():
         log_with_time("Move sequence:", color=Fore.GREEN)
         for move in moves:
             sc, w, d, r0, c0 = move
-            log_with_time(f"  {w} at ({r0},{c0}) {d} scoring {sc}", color=Fore.GREEN)
+            log_with_time(f"  {w} at {r0},{c0},{d} scoring {sc}", color=Fore.GREEN)
         log_with_time("Final simulated board:", color=Fore.GREEN)
         print()
         print_board(board_after, original_bonus)
@@ -302,7 +303,7 @@ def run_solver():
         log_with_time("Move sequence:", color=Fore.GREEN)
         for move in best_moves:
             sc, w, d, r0, c0 = move
-            log_with_time(f"  {w} at ({r0},{c0}) {d} scoring {sc}", color=Fore.GREEN)
+            log_with_time(f"  {w} at {r0},{c0},{d} scoring {sc}", color=Fore.GREEN)
         log_with_time("Final simulated board:", color=Fore.GREEN)
         print()
         print_board(best_board, original_bonus)
@@ -326,7 +327,7 @@ def run_solver():
 
         if best_first_move:
             log_with_time(
-                f"High score deep dive starting from {best_first_move[1]} at ({best_first_move[3]},{best_first_move[4]}) {best_first_move[2]}",
+                f"High score deep dive starting from {best_first_move[1]} at {best_first_move[3]},{best_first_move[4]},{best_first_move[2]}",
                 color=Fore.YELLOW,
             )
             rack_count = Counter(rack)
@@ -349,7 +350,7 @@ def run_solver():
                 for move in dive_moves:
                     sc, w, d, r0, c0 = move
                     log_with_time(
-                        f"  {w} at ({r0},{c0}) {d} scoring {sc}",
+                        f"  {w} at {r0},{c0},{d} scoring {sc}",
                         color=Fore.YELLOW,
                     )
                 log_with_time("Final board:", color=Fore.YELLOW)

--- a/tests/test_board_valid.py
+++ b/tests/test_board_valid.py
@@ -4,13 +4,13 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import pytest
 from board import board_valid
-from utils import N
+from utils import N, Direction
 
 def make_board(words, positions, direction):
     board = [['' for _ in range(N)] for _ in range(N)]
     for word, (r, c) in zip(words, positions):
         for i, ch in enumerate(word):
-            if direction == 'H':
+            if direction == Direction.ACROSS:
                 board[r][c + i] = ch
             else:
                 board[r + i][c] = ch
@@ -18,25 +18,25 @@ def make_board(words, positions, direction):
 
 
 def test_single_word_valid():
-    board = make_board(['CAT'], [(0, 0)], 'H')
+    board = make_board(['CAT'], [(0, 0)], Direction.ACROSS)
     wordset = {'CAT'}
     assert board_valid(board, wordset)
 
 
 def test_two_connected_words_valid():
-    board = make_board(['CAT', 'AT'], [(0, 0), (0, 1)], 'H')
+    board = make_board(['CAT', 'AT'], [(0, 0), (0, 1)], Direction.ACROSS)
     wordset = {'CAT', 'AT'}
     assert board_valid(board, wordset)
 
 
 def test_two_disconnected_words_invalid():
-    board = make_board(['CAT', 'DOG'], [(0, 0), (2, 0)], 'H')
+    board = make_board(['CAT', 'DOG'], [(0, 0), (2, 0)], Direction.ACROSS)
     wordset = {'CAT', 'DOG'}
     assert not board_valid(board, wordset)
 
 
 def test_word_not_in_wordset_invalid():
-    board = make_board(['CAT'], [(0, 0)], 'H')
+    board = make_board(['CAT'], [(0, 0)], Direction.ACROSS)
     wordset = {'DOG'}
     assert not board_valid(board, wordset)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,6 +7,7 @@ import io
 from board import get_letter_mask, place_word, compute_board_score, score_word, board_valid
 from score_cache import board_to_tuple, board_hash, cached_board_score
 import utils
+from utils import Direction
 import contextlib
 
 def pytest_configure():
@@ -21,7 +22,7 @@ def test_place_word_and_score():
     board = [['' for _ in range(5)] for _ in range(5)]
     bonus = [['' for _ in range(5)] for _ in range(5)]
     bonus[1][1] = 'DL'
-    place_word(board, 'CAT', 0, 0, 'H')
+    place_word(board, 'CAT', 0, 0, Direction.ACROSS)
     assert board[0][:3] == ['C', 'A', 'T']
     score = compute_board_score(board, bonus)
     # C=3, A=1, T=1, total=3+1+1=5 (no bonus used)
@@ -93,7 +94,7 @@ def test_empty_board_and_bonus():
     bonus = [['DL' if (r==c) else '' for c in range(5)] for r in range(5)]
     assert compute_board_score(board, bonus) == 0
     # Place a word on DL
-    place_word(board, 'DOG', 0, 0, 'H')
+    place_word(board, 'DOG', 0, 0, Direction.ACROSS)
     score = compute_board_score(board, bonus)
     # D=2*2, O=1, G=2, total=4+1+2=7
     assert score == 7
@@ -204,10 +205,10 @@ def test_print_board_output(monkeypatch):
 def test_place_word_vertical_and_oob():
     import board
     board_data = [['' for _ in range(5)] for _ in range(5)]
-    board.place_word(board_data, 'DOG', 0, 0, 'V')
+    board.place_word(board_data, 'DOG', 0, 0, Direction.DOWN)
     assert [board_data[i][0] for i in range(3)] == ['D', 'O', 'G']
     # Out of bounds should not raise, and only in-bounds letters placed
-    board.place_word(board_data, 'TOOLONGWORD', 0, 0, 'H')
+    board.place_word(board_data, 'TOOLONGWORD', 0, 0, Direction.ACROSS)
     # Only first 5 letters placed
     assert board_data[0][:5] == list('TOOLONGWORD')[:5]
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,7 +1,7 @@
 import pytest
 from search import explore_alternatives
 from board import board_valid
-from utils import N
+from utils import N, Direction
 from collections import Counter
 import random
 import string
@@ -18,7 +18,7 @@ def test_explore_alternatives():
     max_moves = 10
 
     # Mock play (score, word, direction, row, col)
-    play = (0, 'AB', 'H', 0, 0)
+    play = (0, 'AB', Direction.ACROSS, 0, 0)
 
     # Call the function
     score, board_result, moves = explore_alternatives(
@@ -45,7 +45,7 @@ def test_explore_alternatives_retries_invalid():
     max_moves = 10
 
     # First play is 'CD', which is not in wordset, so should be invalid
-    play_invalid = (0, 'CD', 'H', 0, 0)
+    play_invalid = (0, 'CD', Direction.ACROSS, 0, 0)
     score, board_result, moves = explore_alternatives(
         play_invalid, board, rack_count, pruned_words, wordset, original_bonus, beam_width, max_moves
     )
@@ -55,7 +55,7 @@ def test_explore_alternatives_retries_invalid():
     assert moves is None
 
     # Now try with a valid play
-    play_valid = (0, 'AB', 'H', 0, 0)
+    play_valid = (0, 'AB', Direction.ACROSS, 0, 0)
     score2, board_result2, moves2 = explore_alternatives(
         play_valid, board, rack_count, pruned_words, wordset, original_bonus, beam_width, max_moves
     )

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -12,6 +12,7 @@ import pytest
 
 import search
 import utils
+from utils import Direction
 from board import board_valid, compute_board_score
 
 def count_words(board):
@@ -76,9 +77,9 @@ def run_games(monkeypatch):
         if not getattr(stub_find_best, 'called', False):
             stub_find_best.called = True
             return [
-                (5, 'HI', 'V', 0, 0),
-                (2, 'IT', 'H', 1, 0),
-                (5, 'HI', 'H', 1, 0),
+                (5, 'HI', Direction.DOWN, 0, 0),
+                (2, 'IT', Direction.ACROSS, 1, 0),
+                (5, 'HI', Direction.ACROSS, 1, 0),
             ]
         return orig_find_best(board, rack_count, words, wordset, touch, original_bonus, top_k)
 
@@ -143,7 +144,7 @@ def test_start_pos_happy(monkeypatch, capsys):
     monkeypatch.setattr(sys, 'argv', [
         'solver.py',
         '--start-word', 'HI',
-        '--start-pos', '0,0,V',
+        '--start-pos', '0,0,D',
         '--depth', '2',
         '--beam-width', '2',
         '--num-games', '1',
@@ -156,7 +157,7 @@ def test_start_pos_happy(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Best placement for 'HI':" in out
     assert "score" in out
-    assert "position (0,0) V" in out
+    assert "position 0,0,D" in out
 
 
 def test_start_pos_impossible(monkeypatch, capsys):
@@ -165,7 +166,7 @@ def test_start_pos_impossible(monkeypatch, capsys):
     monkeypatch.setattr(sys, 'argv', [
         'solver.py',
         '--start-word', 'HI',
-        '--start-pos', '5,5,H',
+        '--start-pos', '5,5,A',
         '--depth', '2',
         '--beam-width', '2',
         '--num-games', '1',
@@ -176,7 +177,7 @@ def test_start_pos_impossible(monkeypatch, capsys):
     monkeypatch.setattr(solver, 'print_board', lambda board, bonus=None: None)
     solver.run_solver()
     out = capsys.readouterr().out
-    assert "Cannot place start word 'HI' at (5,5) H." in out
+    assert "Cannot place start word 'HI' at 5,5,A." in out
 
 
 def test_start_pos_invalid_format(monkeypatch, capsys):

--- a/utils.py
+++ b/utils.py
@@ -4,11 +4,18 @@ import threading
 import json
 import os
 from colorama import Fore, Style, init
+from enum import Enum
 
 init()
 
 # Board dimension
 N = 5
+
+# Word placement directions
+class Direction(str, Enum):
+    """Possible directions for word placement."""
+    ACROSS = 'A'
+    DOWN = 'D'
 
 # Bonus-square codes
 MAPPING = {


### PR DESCRIPTION
## Summary
- introduce `Direction` enum for Across/Down
- refactor board and search logic to use `Direction` values
- update solver output format to `row,col,dir` and accept new letters
- adjust unit tests for new direction constants

## Testing
- `pip install -r requires.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b71fb096083229a1a2bba625ce604